### PR TITLE
Add vector support for Hal state

### DIFF
--- a/src/hal.rs
+++ b/src/hal.rs
@@ -25,7 +25,10 @@ pub enum HalState {
     String(StrBuf),
     Boolean(bool),
     Null,
+    List(List),
 }
+
+pub type List = Vec<HalState>;
 
 /// A trait for converting values to Hal data
 pub trait ToHalState {
@@ -53,13 +56,22 @@ impl ToHalState for StrBuf {
     fn to_hal_state(&self) -> HalState { String((*self).clone()) }
 }
 
+impl ToHalState for &'static str {
+    fn to_hal_state(&self) -> HalState { String((*self).to_strbuf()) }
+}
+
+impl<T:ToHalState> ToHalState for Vec<T> {
+    fn to_hal_state(&self) -> HalState { List(self.iter().map(|elt| elt.to_hal_state()).collect()) }
+}
+
 impl ToJson for HalState {
     fn to_json(&self) -> Json { 
         match *self {
             Number(v) => v.to_json(),
             String(ref v) => v.to_json(),
             Boolean(v) => v.to_json(),
-            Null => ().to_json()
+            Null => ().to_json(),
+            List(ref v) => v.to_json(),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -139,3 +139,14 @@ fn order_to_hal() {
     let output = r#"{"_links":{"self":{"href":"https://www.example.com/orders/1"}},"currency":"USD","status":"processing","total":20}"#;
     assert_eq!(order.to_hal().to_json().to_str(), output.to_owned());
 }
+
+#[test]
+fn list_to_hal_state() {
+    let friends = vec!("Mary", "Timmy", "Sally", "Wally");
+
+    let hal = Resource::with_self("/user/1")
+        .add_state("friends", friends.to_hal_state());
+
+    let output = r#"{"_links":{"self":{"href":"/user/1"}},"friends":["Mary","Timmy","Sally","Wally"]}"#;
+    assert_eq!(hal.to_json().to_str(), output.to_owned());
+}


### PR DESCRIPTION
A vector can now be treated as Hal state if the vector type can has
support for the `ToHalState` trait.
